### PR TITLE
Create middlewares verify slack request

### DIFF
--- a/app/api/message.py
+++ b/app/api/message.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/", response_model=ConversationResponse)
 async def conversation(
     token: str = Form(...),
     team_id: str = Form(...),

--- a/app/middlewares/verify_slack_request.py
+++ b/app/middlewares/verify_slack_request.py
@@ -25,7 +25,9 @@ class VerifySlackRequest(BaseHTTPMiddleware):
         request_body = await request.body()
 
         # Add your verification logic here
-        if not verifier.is_valid_request(request_body, slack_signature, slack_request_timestamp):
+        if not verifier.is_valid_request(
+            request_body, slack_signature, slack_request_timestamp
+        ):
             raise HTTPException(status_code=400, detail="Invalid Slack request")
 
         response = await call_next(request)

--- a/app/middlewares/verify_slack_request.py
+++ b/app/middlewares/verify_slack_request.py
@@ -7,6 +7,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class VerifySlackRequest(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         slack_signature = request.headers.get("x-slack-signature")

--- a/app/middlewares/verify_slack_request.py
+++ b/app/middlewares/verify_slack_request.py
@@ -1,0 +1,32 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from slack_sdk.signature import SignatureVerifier
+from fastapi import HTTPException
+from app.config.settings import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+class VerifySlackRequest(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        slack_signature = request.headers.get("x-slack-signature")
+        slack_request_timestamp = request.headers.get("x-slack-request-timestamp")
+
+        if not settings.slack_signing_secret:
+            response = await call_next(request)
+            return response
+
+        if not slack_signature or not slack_request_timestamp:
+            raise HTTPException(
+                status_code=400, detail="Missing Slack signature or timestamp"
+            )
+
+        verifier = SignatureVerifier(signing_secret=settings.slack_signing_secret)
+        request_body = await request.body()
+
+        # Add your verification logic here
+        if not verifier.is_valid_request(request_body, slack_signature, slack_request_timestamp):
+            raise HTTPException(status_code=400, detail="Invalid Slack request")
+
+        response = await call_next(request)
+        return response

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,12 +1,15 @@
 """All API Routers."""
 
 from fastapi import APIRouter
-
 from app.api import message
+from app.middlewares.verify_slack_request import VerifySlackRequest
 
 api_router = APIRouter()
-api_router.include_router(
+conversation_router = APIRouter()
+conversation_router.include_router(
     message.router,
     prefix="/conversation",
     tags=["conversation"],
 )
+conversation_router.middleware("http")(VerifySlackRequest)
+api_router.include_router(conversation_router)

--- a/main.py
+++ b/main.py
@@ -5,14 +5,13 @@ import logging.config
 import logging
 from datetime import datetime
 from app.routes.api import api_router
-from app.middlewares.verify_slack_request import VerifySlackRequest
+
 
 logging.basicConfig(
     filename="app.log", level=logging.INFO, format="%(asctime)s %(message)s"
 )
 logger = logging.getLogger(__name__)
 app = FastAPI(title="Slack bot request review", debug=True)
-app.add_middleware(VerifySlackRequest)
 app.include_router(api_router)
 
 


### PR DESCRIPTION
This pull request includes changes to introduce a new middleware for verifying Slack requests and refactors the existing code to use this middleware. The most important changes include adding the new `VerifySlackRequest` middleware, updating the conversation endpoint to use a response model, and refactoring the API routes to include the new middleware.

### Middleware Addition:
* [`app/middlewares/verify_slack_request.py`](diffhunk://#diff-b2fb9194cc2564939c7c79ca3fee76c61776fbbd8a646833df2ba32c24e45f52R1-R35): Added `VerifySlackRequest` middleware to verify Slack requests using the `SignatureVerifier` from the `slack_sdk`.

### API Route Updates:
* [`app/routes/api.py`](diffhunk://#diff-e158ec3a99f98b47e89a6a0ddc8b8703a79a3b21e6edf9f56e2263885011d826L4-R15): Refactored to include the `VerifySlackRequest` middleware in the conversation routes.

### Endpoint Enhancements:
* [`app/api/message.py`](diffhunk://#diff-c0dbceda9a4c080302d1de35af8ce1b1111321afa48ab89430f3908883b50160L9-R9): Updated the conversation endpoint to use `ConversationResponse` as the response model.

### Code Cleanup:
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L3-R8): Removed the old Slack request verification middleware and cleaned up unused imports. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L3-R8) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L40-L64)