### PR TITLE
Enhance API with response model validation for conversations

### DIFF
--- a/app/api/message.py
+++ b/app/api/message.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/", response_model=ConversationResponse)
 async def conversation(
     token: str = Form(...),
     team_id: str = Form(...),

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ async def verify_slack_request(request: Request, call_next):
     slack_signature = request.headers.get("x-slack-signature")
     slack_request_timestamp = request.headers.get("x-slack-request-timestamp")
 
-    if not settings.slack_signing_secret:
+    if not settings.slack_signing_secret or not request.url.path.startswith("/conversation"):
         response = await call_next(request)
         return response
 

--- a/main.py
+++ b/main.py
@@ -44,7 +44,9 @@ async def verify_slack_request(request: Request, call_next):
     slack_signature = request.headers.get("x-slack-signature")
     slack_request_timestamp = request.headers.get("x-slack-request-timestamp")
 
-    if not settings.slack_signing_secret or not request.url.path.startswith("/conversation"):
+    if not settings.slack_signing_secret or not request.url.path.startswith(
+        "/conversation"
+    ):
         response = await call_next(request)
         return response
 


### PR DESCRIPTION
This pull request includes modifications to the API response model and the request verification logic. The most important changes are:

API response model update:
* [`app/api/message.py`](diffhunk://#diff-c0dbceda9a4c080302d1de35af8ce1b1111321afa48ab89430f3908883b50160L9-R9): Added `response_model=ConversationResponse` to the `@router.post` decorator to specify the expected response model for the conversation endpoint.

Request verification logic enhancement:
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L47-R47): Updated the `verify_slack_request` function to include an additional check for the request URL path, ensuring it starts with `/conversation` before proceeding with signature verification.