### PR TITLE
Improve wording in PR review request messages

### DIFF
--- a/app/decorators/review_message.py
+++ b/app/decorators/review_message.py
@@ -14,7 +14,7 @@ class ReviewMessageDecorator:
             message_review += "\n"
 
         return (
-            f"Hi team, please help {'<@' + user_id + '> ' if user_id else ''}review this PR {pr_url} \n"
+            f"Hello team, please assist {'<@' + user_id + '> ' if user_id else ''}in reviewing this PR {pr_url} \n"
             f"Summary: {title} \n"
             f"{message_review}"
             "Thank you! :pepe_love:"


### PR DESCRIPTION
This pull request includes a small change to the `message` method in the `app/decorators/review_message.py` file. The change updates the wording of the review request message for better clarity.

* [`app/decorators/review_message.py`](diffhunk://#diff-19e89206c19fff014ce01cf27838a1fe7d8da8fb538f4276e336ef98544f566cL17-R17): Changed the wording from "please help" to "please assist" in the review request message to improve clarity.